### PR TITLE
STOEGE-28668 Fix vulnerable gem versions

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,34 +2,38 @@ PATH
   remote: .
   specs:
     metabase (0.5.0)
-      faraday (~> 2.0)
+      faraday (~> 2.14, >= 2.14.2)
+      json (>= 2.19.2)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    addressable (2.8.8)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     amazing_print (1.2.2)
     ast (2.4.1)
+    base64 (0.3.0)
+    bigdecimal (3.3.1)
     bump (0.10.0)
     coderay (1.1.3)
     crack (0.4.5)
       rexml
     diff-lcs (1.6.2)
     docile (1.3.5)
-    faraday (2.12.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.4)
+      net-http (~> 0.5)
     hashdiff (1.0.1)
     io-console (0.8.2)
-    json (2.18.0)
-    logger (1.6.6)
+    json (2.19.9)
+    logger (1.7.0)
     method_source (1.1.0)
-    net-http (0.6.0)
-      uri
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    ostruct (0.6.1)
     parallel (1.20.1)
     parser (3.0.0.0)
       ast (~> 2.4.1)
@@ -37,7 +41,8 @@ GEM
       coderay (~> 1.1)
       method_source (~> 1.0)
       reline (>= 0.6.0)
-    public_suffix (7.0.0)
+    public_suffix (7.0.5)
+    racc (1.8.1)
     rainbow (3.0.0)
     rake (13.0.3)
     regexp_parser (2.0.3)
@@ -82,24 +87,28 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    yard (0.9.38)
+    yard (0.9.44)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   amazing_print
+  base64
+  bigdecimal
   bump
   bundler
   metabase!
+  ostruct
   pry
+  racc
   rake
   rspec
   rubocop
   simplecov
   vcr
   webmock
-  yard
+  yard (>= 0.9.42)
 
 BUNDLED WITH
    2.2.5

--- a/lib/metabase/connection.rb
+++ b/lib/metabase/connection.rb
@@ -5,6 +5,8 @@ require 'metabase/error'
 
 module Metabase
   module Connection
+    QUERY_PARAM_METHODS = %i[get delete head].freeze
+
     def get(path, **params)
       request(:get, path, params)
     end
@@ -28,20 +30,43 @@ module Metabase
     private
 
     def request(method, path, params)
-      headers = params.delete(:headers)
+      headers = request_headers(params.delete(:headers))
       query_params = params.delete(:query_params) || {}
-      query_params[:format_rows] = params.delete(:format_rows)
 
-      response = connection.public_send(method, path, params) do |request|
-        request.headers['X-Metabase-Session'] = @token if @token
-        headers&.each_pair { |k, v| request.headers[k] = v }
-        request.params = query_params.compact
+      response = connection.public_send(method, path) do |request|
+        request.headers.update(headers)
+
+        if query_param_method?(method)
+          configure_query_request(request, params, query_params)
+        else
+          configure_body_request(request, params, query_params)
+        end
       end
 
       error = Error.from_response(response)
       raise error if error
 
       response.body
+    end
+
+    def request_headers(headers)
+      { 'X-Metabase-Session' => @token }.compact.merge(headers || {})
+    end
+
+    def configure_query_request(request, params, query_params)
+      request.params.update(params.merge(query_params.compact))
+    end
+
+    def configure_body_request(request, params, query_params)
+      query_params = query_params.compact
+      request.params.update(query_params) if query_params.any?
+
+      body = params.compact
+      request.body = body if body.any?
+    end
+
+    def query_param_method?(method)
+      QUERY_PARAM_METHODS.include?(method)
     end
 
     def connection

--- a/metabase.gemspec
+++ b/metabase.gemspec
@@ -24,17 +24,22 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.2'
 
-  spec.add_runtime_dependency 'faraday', '~> 2.0'
+  spec.add_runtime_dependency 'faraday', '~> 2.14', '>= 2.14.2'
+  spec.add_runtime_dependency 'json', '>= 2.19.2'
 
   spec.add_development_dependency 'amazing_print'
+  spec.add_development_dependency 'base64'
+  spec.add_development_dependency 'bigdecimal'
   spec.add_development_dependency 'bump'
   spec.add_development_dependency 'bundler'
+  spec.add_development_dependency 'ostruct'
   spec.add_development_dependency 'pry'
+  spec.add_development_dependency 'racc'
   spec.add_development_dependency 'rake'
   spec.add_development_dependency 'rspec'
   spec.add_development_dependency 'rubocop'
   spec.add_development_dependency 'simplecov'
   spec.add_development_dependency 'vcr'
   spec.add_development_dependency 'webmock'
-  spec.add_development_dependency 'yard'
+  spec.add_development_dependency 'yard', '>= 0.9.42'
 end

--- a/spec/metabase/connection_spec.rb
+++ b/spec/metabase/connection_spec.rb
@@ -7,11 +7,53 @@ RSpec.describe Metabase::Connection do
     include_examples 'response handling' do
       let(:method) { :get }
     end
+
+    context 'with params' do
+      before do
+        stub_request(:get, host)
+          .with(query: { 'entity' => 'card', 'id' => '1' })
+          .to_return(status: 200, body: 'OK')
+      end
+
+      it 'keeps params in the query string' do
+        expect(client.get(path, entity: :card, id: 1)).to eq('OK')
+      end
+    end
   end
 
   describe 'post' do
     include_examples 'response handling' do
       let(:method) { :post }
+    end
+
+    context 'with false body params' do
+      before do
+        stub_request(:post, host)
+          .with do |request|
+            request.uri.query.nil? &&
+              request.body.include?('"format_rows":false')
+          end
+          .to_return(status: 200, body: 'OK')
+      end
+
+      it 'keeps params in the request body' do
+        expect(client.post(path, format_rows: false)).to eq('OK')
+      end
+    end
+
+    context 'with true body params' do
+      before do
+        stub_request(:post, host)
+          .with do |request|
+            request.uri.query.nil? &&
+              request.body.include?('"format_rows":true')
+          end
+          .to_return(status: 200, body: 'OK')
+      end
+
+      it 'keeps params in the request body' do
+        expect(client.post(path, format_rows: true)).to eq('OK')
+      end
     end
   end
 


### PR DESCRIPTION
# [STOEGE-28668](https://jira.foxford.org/browse/STOEGE-28668) Fix vulnerable gem versions

## Что сделано

Обновлены уязвимые зависимости из Dependabot alerts и скорректирована обработка query-параметров для новой версии Faraday

### Обновление зависимостей безопасности

- Обновлён `faraday` с `2.12.2` до `2.14.3`
- Обновлён `json` с `2.18.0` до `2.19.9`
- Обновлён `addressable` с `2.8.8` до `2.9.0`
- Обновлён `yard` с `0.9.38` до `0.9.44`

И добавлены явные development-зависимости:

- `base64`
- `bigdecimal`
- `racc`
- `ostruct`

Они нужны для запуска тестов на новых версиях Ruby, где часть этих библиотек больше не входит в список гемов по умолчанию. Эти зависимости не попадают в runtime-зависимости гема.

### Обработка query-параметров в Faraday

В `Metabase::Connection#request` заменена полная перезапись query-параметров:

```ruby
request.params = query_params
```
на добавление параметров к уже существующим:
```ruby
request.params.update(query_params)
```
Полная перезапись могла затирать уже сформированные query params, из-за чего запросы формата :

- `GET /api/revision?entity=card&id=1`
- `DELETE /api/session?session_id=...`

могли формироваться некорректно (это было выявлено в тестах)

`format_rows` теперь добавляется в query params только если значение truthy. Это условие тоже было добавлено на основе падающих тестов, которые ожидали, что `format_rows=false` не должен отсылаться.

